### PR TITLE
Allow local file system saves; other OAM changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.env
+.envrc
+node_modules/
+npm-debug.log
+
+# Emacs
+\#*#
+*~
+.#*

--- a/activities.js
+++ b/activities.js
@@ -4,7 +4,7 @@ var os = require("os");
 
 var async = require("async");
 
-var swfr = require("./index");
+var worker = require("./index").Worker;
 
 var activityHandler = function(i) {
   return function(task, callback) {
@@ -26,7 +26,7 @@ var activityHandler = function(i) {
 };
 
 async.times(os.cpus().length, function(i) {
-  return swfr({
+  return worker({
     domain: "SplitMerge",
     taskList: "splitmerge_activity_tasklist"
   }, activityHandler(i));

--- a/activities.js
+++ b/activities.js
@@ -4,7 +4,7 @@ var os = require("os");
 
 var async = require("async");
 
-var worker = require("./index").Worker;
+var activity = require("./index").activity;
 
 var activityHandler = function(i) {
   return function(task, callback) {
@@ -26,7 +26,7 @@ var activityHandler = function(i) {
 };
 
 async.times(os.cpus().length, function(i) {
-  return worker({
+  return activity({
     domain: "SplitMerge",
     taskList: "splitmerge_activity_tasklist"
   }, activityHandler(i));

--- a/decider.js
+++ b/decider.js
@@ -9,8 +9,8 @@ var assert = require("assert"),
 var _ = require("highland"),
     AWS = require("aws-sdk");
 
-var Decider = require("./lib/decider"),
-    SyncDecider = require("./lib/sync_decider");
+var DeciderWorker = require("./lib/decider"),
+    SyncDeciderWorker = require("./lib/sync_decider");
 
 // TODO this overrides any file-based configuration that may have occurred
 AWS.config.update({
@@ -33,7 +33,7 @@ module.exports = function(options, fn) {
       objectMode: true
     });
 
-    source.pipe(new SyncDecider(fn));
+    source.pipe(new SyncDeciderWorker(fn));
 
     worker.cancel = function() {
       source.end();
@@ -130,7 +130,7 @@ module.exports = function(options, fn) {
   });
 
   if (fn) {
-    source.pipe(new Decider(fn));
+    source.pipe(new DeciderWorker(fn));
 
     worker.cancel = function() {
       source.destroy();

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ AWS.config.update({
 
 var swf = new AWS.SWF();
 
-var WorkerWritable = function(fn) {
+var ActivityWorker = function(fn) {
   stream.Writable.call(this, {
     objectMode: true,
     highWaterMark: 1 // limit the number of buffered tasks
@@ -88,16 +88,16 @@ var WorkerWritable = function(fn) {
   };
 };
 
-util.inherits(WorkerWritable, stream.Writable);
+util.inherits(ActivityWorker, stream.Writable);
 
-module.exports.Decider = decider;
+module.exports.decider = decider;
 
 /**
  * Available options:
  * * domain - Workflow domain (required)
  * * taskList - Task list (required)
  */
-module.exports.Worker = function(options, fn) {
+module.exports.activity = function(options, fn) {
   assert.ok(options.domain, "options.domain is required");
   assert.ok(options.taskList, "options.taskList is required");
 
@@ -159,7 +159,7 @@ module.exports.Worker = function(options, fn) {
   });
 
   if (fn) {
-    source.pipe(new WorkerWritable(fn));
+    source.pipe(new ActivityWorker(fn));
 
     worker.cancel = function() {
       source.destroy();

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ var assert = require("assert"),
 var _ = require("highland"),
     AWS = require("aws-sdk");
 
+var decider = require("./decider.js");
+
 var agent = new https.Agent({
   // Infinity just boosts the max value; in practice this will be no larger
   // than your configured concurrency (number of workers)
@@ -25,7 +27,7 @@ AWS.config.update({
 
 var swf = new AWS.SWF();
 
-var Worker = function(fn) {
+var WorkerWritable = function(fn) {
   stream.Writable.call(this, {
     objectMode: true,
     highWaterMark: 1 // limit the number of buffered tasks
@@ -86,14 +88,16 @@ var Worker = function(fn) {
   };
 };
 
-util.inherits(Worker, stream.Writable);
+util.inherits(WorkerWritable, stream.Writable);
+
+module.exports.Decider = decider;
 
 /**
  * Available options:
  * * domain - Workflow domain (required)
  * * taskList - Task list (required)
  */
-module.exports = function(options, fn) {
+module.exports.Worker = function(options, fn) {
   assert.ok(options.domain, "options.domain is required");
   assert.ok(options.taskList, "options.taskList is required");
 
@@ -155,7 +159,7 @@ module.exports = function(options, fn) {
   });
 
   if (fn) {
-    source.pipe(new Worker(fn));
+    source.pipe(new WorkerWritable(fn));
 
     worker.cancel = function() {
       source.destroy();

--- a/lib/activities/buildvrt.js
+++ b/lib/activities/buildvrt.js
@@ -18,38 +18,39 @@ module.exports = function buildVRT(files, outputUri, callback) {
       return done(new Error("No files provided for " + localOutputPath));
     }
 
-    if(files.length < 1000) {
-      var args = [
-        localOutputPath
-      ].concat(files);
+    return tmp.tmpName({
+      postfix: ".txt"
+    }, function(err, fileList) {
+      if (err) {
+        return done(err);
+      }
+      // var fd = fs.openSync(fileList, 'w');
+      // var len = files.length;
+      // for(var i = 0; i < len; i++) {
+      //   fs.writeSync(fd, files[i] + "\n");
+      // }
+      // fs.closeSync(fd);
 
-      return shell("gdalbuildvrt", args, {}, done);
-    } else {
-
-      return tmp.tmpName({
-        postfix: ".txt"
-      }, function(err, fileList) {
-        if (err) {
-          return done(err);
-        }
-        var fd = fs.openSync(fileList, 'w');
-        var len = files.length;
-        for(var i = 0; i < len; i++) {
-          fs.writeSync(fd, files[i] + "\n");
-        }
-        fs.closeSync(fd);
+      var list = fs.createWriteStream(fileList, {
+        encoding: "utf8"
+      }).on("finish", function() {
         var args = [
           "-input_file_list", fileList,
           localOutputPath
         ];
 
-        console.log("gdalbuildvrt " + args);
         return shell("gdalbuildvrt", args, {}, function(err) {
           fs.unlink(fileList, function() {});
           done(err);
         });
       });
-    }
+
+      files.forEach(function(f) {
+        list.write(f + "\n");
+      });
+
+      return list.end();
+    });
   });
 };
 

--- a/lib/activities/buildvrt.js
+++ b/lib/activities/buildvrt.js
@@ -1,24 +1,55 @@
 "use strict";
 
-var s3Output = require("./s3_output"),
+var fs = require('fs'),
+    path = require('path');
+
+var tmp = require('tmp');
+
+var output = require("./output"),
     shell = require("./shell");
 
-module.exports = function buildVRT(files, output, callback) {
-  return s3Output(output, callback, function(err, outputFilename, done) {
+module.exports = function buildVRT(files, outputUri, callback) {
+  return output(outputUri, callback, function(err, localOutputPath, done) {
     if (err) {
       return callback(err);
     }
 
     if (files.length === 0) {
-      return done(new Error("No files provided for " + outputFilename));
+      return done(new Error("No files provided for " + localOutputPath));
     }
 
-    var args = [
-      outputFilename
-    ].concat(files);
+    if(files.length < 1000) {
+      var args = [
+        localOutputPath
+      ].concat(files);
 
-    // TODO this will fail if the list is too long
-    return shell("gdalbuildvrt", args, {}, done);
+      return shell("gdalbuildvrt", args, {}, done);
+    } else {
+
+      return tmp.tmpName({
+        postfix: ".txt"
+      }, function(err, fileList) {
+        if (err) {
+          return done(err);
+        }
+        var fd = fs.openSync(fileList, 'w');
+        var len = files.length;
+        for(var i = 0; i < len; i++) {
+          fs.writeSync(fd, files[i] + "\n");
+        }
+        fs.closeSync(fd);
+        var args = [
+          "-input_file_list", fileList,
+          localOutputPath
+        ];
+
+        console.log("gdalbuildvrt " + args);
+        return shell("gdalbuildvrt", args, {}, function(err) {
+          fs.unlink(fileList, function() {});
+          done(err);
+        });
+      });
+    }
   });
 };
 

--- a/lib/activities/get_extent.js
+++ b/lib/activities/get_extent.js
@@ -8,6 +8,8 @@ var shell = require("./shell");
 
 var log = debug("swfr:shell");
 
+var coordinateRegex = /([\[\(])([^,]*),(.*?)([\]\)])/;
+
 /**
  * Fetch the extent of a raster.
  *
@@ -20,7 +22,7 @@ module.exports = function getExtent(uri, callback) {
   ];
 
   // Regex to extract coordinates.
-  var re = /([\[\(])([^,]*),(.*?)([\]\)])/;
+
 
   return shell("gdalinfo", args, {}, function(err, stdout) {
     if (err) {
@@ -31,14 +33,14 @@ module.exports = function getExtent(uri, callback) {
       return line.match(/Upper Left|Lower Right/);
     })
     .map(function(line) {
-      log(line);
-      var m = line.match(re);
-      var x = Number(m[2]);
-      var y = Number(m[3]);
+      var m = line.match(coordinateRegex),
+          x = +m[2],
+          y = +m[3];
+
       return [x, y];
     });
     
-    console.log("Got extent: %s", extent);
+    log("Got extent: %s", extent);
     return callback(null, extent);
   });
 };

--- a/lib/activities/get_extent.js
+++ b/lib/activities/get_extent.js
@@ -1,9 +1,12 @@
 "use strict";
 
-var url = require("url"),
+var debug = require("debug"),
+    url = require("url"),
     util = require("util");
 
 var shell = require("./shell");
+
+var log = debug("swfr:shell");
 
 /**
  * Fetch the extent of a raster.
@@ -11,11 +14,13 @@ var shell = require("./shell");
  * @returns [upper left, lower right]
  */
 module.exports = function getExtent(uri, callback) {
-  uri = url.parse(uri);
-
   var args = [
-    util.format("http://s3.amazonaws.com/%s%s", uri.hostname, uri.pathname)
+    "-nofl", // In case this is a VRT with too many files to be caught in stdout
+    uri
   ];
+
+  // Regex to extract coordinates.
+  var re = /([\[\(])([^,]*),(.*?)([\]\)])/;
 
   return shell("gdalinfo", args, {}, function(err, stdout) {
     if (err) {
@@ -26,12 +31,14 @@ module.exports = function getExtent(uri, callback) {
       return line.match(/Upper Left|Lower Right/);
     })
     .map(function(line) {
-      return line.replace(/^.+\(([-\d\.]+),\s*([-\d\.]+).+$/, "$1 $2").split(" ");
-    })
-    .map(function(pair) {
-      return pair.map(Number);
+      log(line);
+      var m = line.match(re);
+      var x = Number(m[2]);
+      var y = Number(m[3]);
+      return [x, y];
     });
-
+    
+    console.log("Got extent: %s", extent);
     return callback(null, extent);
   });
 };

--- a/lib/activities/output.js
+++ b/lib/activities/output.js
@@ -5,20 +5,25 @@ var fs = require("fs"),
     url = require("url");
 
 var debug = require("debug"),
-    mkdirp = require('mkdirp');
+    mkdirp = require("mkdirp");
 
 var s3Output = require("./s3_output");
 
-var log = debug("swfr:upload");
-
 module.exports = function(outputUri, done, fn) {
-  if(outputUri.indexOf("s3://") === 0) {
+  var uri = url.parse(outputUri);
+
+  if (uri.protocol === "s3:") {
     return s3Output(outputUri, done, fn);
-  } 
+  }
 
   // Local output
-  
-  var call = function() {
+
+  var d = path.dirname(outputUri);
+  return mkdirp(d, function (err) {
+    if (err) {
+      return done(err);
+    }
+
     return fn(null, outputUri, function(err, save) {
       if (err) {
         // wrapped function failed; propagate the error
@@ -27,20 +32,5 @@ module.exports = function(outputUri, done, fn) {
 
       return done(null, outputUri);
     });
-  };
-
-  var d = path.dirname(outputUri);
-  return fs.exists(d, function(exists) {
-    if(!exists) {
-      return mkdirp(d, function (err) {
-        if (err) {
-          return done(err);
-        }
-
-        return call();
-      });
-    }
-
-    return call();
   });
 };

--- a/lib/activities/output.js
+++ b/lib/activities/output.js
@@ -1,0 +1,46 @@
+"use strict";
+
+var fs = require("fs"),
+    path = require("path"),
+    url = require("url");
+
+var debug = require("debug"),
+    mkdirp = require('mkdirp');
+
+var s3Output = require("./s3_output");
+
+var log = debug("swfr:upload");
+
+module.exports = function(outputUri, done, fn) {
+  if(outputUri.indexOf("s3://") === 0) {
+    return s3Output(outputUri, done, fn);
+  } 
+
+  // Local output
+  
+  var call = function() {
+    return fn(null, outputUri, function(err, save) {
+      if (err) {
+        // wrapped function failed; propagate the error
+        return done(err);
+      }
+
+      return done(null, outputUri);
+    });
+  };
+
+  var d = path.dirname(outputUri);
+  return fs.exists(d, function(exists) {
+    if(!exists) {
+      return mkdirp(d, function (err) {
+        if (err) {
+          return done(err);
+        }
+
+        return call();
+      });
+    }
+
+    return call();
+  });
+};

--- a/lib/activities/reproject.js
+++ b/lib/activities/reproject.js
@@ -4,17 +4,17 @@ var assert = require("assert");
 
 var clone = require("clone");
 
-var s3Output = require("./s3_output"),
+var output = require("./output"),
     shell = require("./shell");
 
-module.exports = function reproject(input, output, options, callback) {
+module.exports = function reproject(localInputPath, outputUri, options, callback) {
   try {
     assert.ok(options.targetSRS, "reproject: Target SRS is required");
   } catch (err) {
     return callback(err);
   }
 
-  return s3Output(output, callback, function(err, outputFilename, done) {
+  return output(outputUri, callback, function(err, localOutputPath, done) {
     if (err) {
       return callback(err);
     }
@@ -27,10 +27,17 @@ module.exports = function reproject(input, output, options, callback) {
       "-co", "tiled=yes",
       "-co", "compress=lzw",
       "-co", "predictor=2",
-      "-r", "bilinear",
-      input,
-      outputFilename
+      "-r", "bilinear"
     ];
+
+    if(options.overwrite) {
+      args.push("-overwrite");
+    }
+
+    args = args.concat([
+      localInputPath,
+      localOutputPath
+    ]);
 
     if (options.srcNoData != null) {
       args.unshift("-srcnodata", options.srcNoData);

--- a/lib/activities/reproject.js
+++ b/lib/activities/reproject.js
@@ -30,7 +30,7 @@ module.exports = function reproject(localInputPath, outputUri, options, callback
       "-r", "bilinear"
     ];
 
-    if(options.overwrite) {
+    if (options.overwrite) {
       args.push("-overwrite");
     }
 

--- a/lib/activities/resample.js
+++ b/lib/activities/resample.js
@@ -28,7 +28,7 @@ module.exports = function resample(localInputPath, outputUri, options, callback)
       "-t_srs", "EPSG:3857",
       "-te", options.targetExtent[0], options.targetExtent[1], options.targetExtent[2], options.targetExtent[3],
       "-tr", options.targetResolution[0], options.targetResolution[1],
-      "-tap",
+//      "-tap",
       "-wm", 256, // allow GDAL to work with larger chunks (diminishing returns after 500MB, supposedly)
       "-wo", "NUM_THREADS=ALL_CPUS",
       "-multi",
@@ -38,7 +38,7 @@ module.exports = function resample(localInputPath, outputUri, options, callback)
       "-r", "bilinear"
     ];
 
-    if(options.overwrite) {
+    if (options.overwrite) {
       args.push("-overwrite");
     }
 

--- a/lib/activities/resample.js
+++ b/lib/activities/resample.js
@@ -5,10 +5,10 @@ var assert = require("assert");
 var clone = require("clone"),
     gdal = require("gdal");
 
-var s3Output = require("./s3_output"),
+var output = require("./output"),
     shell = require("./shell");
 
-module.exports = function resample(input, output, options, callback) {
+module.exports = function resample(localInputPath, outputUri, options, callback) {
   try {
     assert.ok(Array.isArray(options.targetExtent), "resample: targetExtent must be an array");
     assert.equal(4, options.targetExtent.length, "resample: targetExtent must be an array of 4 elements");
@@ -18,7 +18,7 @@ module.exports = function resample(input, output, options, callback) {
     return callback(err);
   }
 
-  return s3Output(output, callback, function(err, outputFilename, done) {
+  return output(outputUri, callback, function(err, localOutputPath, done) {
     if (err) {
       return callback(err);
     }
@@ -29,18 +29,23 @@ module.exports = function resample(input, output, options, callback) {
       "-te", options.targetExtent[0], options.targetExtent[1], options.targetExtent[2], options.targetExtent[3],
       "-tr", options.targetResolution[0], options.targetResolution[1],
       "-tap",
-      "-srcnodata", -32768,
-      "-dstnodata", -32768,
       "-wm", 256, // allow GDAL to work with larger chunks (diminishing returns after 500MB, supposedly)
       "-wo", "NUM_THREADS=ALL_CPUS",
       "-multi",
       "-co", "tiled=yes",
       "-co", "compress=lzw",
       "-co", "predictor=2",
-      "-r", "bilinear",
-      input,
-      outputFilename
+      "-r", "bilinear"
     ];
+
+    if(options.overwrite) {
+      args.push("-overwrite");
+    }
+
+    args = args.concat([
+      localInputPath,
+      localOutputPath
+    ]);
 
     var env = clone(process.env);
 
@@ -58,7 +63,7 @@ module.exports = function resample(input, output, options, callback) {
       }
 
       try {
-        gdal.open(outputFilename).bands.get(1).getStatistics(false, true);
+        gdal.open(localOutputPath).bands.get(1).getStatistics(false, true);
       } catch (err) {
         // likely "Failed to compute statistics, no valid pixels found in
         // sampling.", which means that it's all NODATA, and thus not worth

--- a/lib/activities/s3_output.js
+++ b/lib/activities/s3_output.js
@@ -71,7 +71,7 @@ module.exports = function(output, done, callback) {
       upload.on("uploaded", cleanup);
 
       upload.on("error", function(err) {
-        return done(err);
+        return done(new Error(err));
       });
 
       // cleanup can't be used, as it would propagate the info as an error

--- a/lib/activities/translate.js
+++ b/lib/activities/translate.js
@@ -15,18 +15,18 @@ module.exports = function translate(localInputPath, outputUri, options, callback
     }
 
     var args = [];
-    if(options.outputFormat) {
+    if (options.outputFormat) {
       args = args.concat(["-of", options.outputFormat]);
     }
 
-    if(options.bands) {
+    if (options.bands) {
       var len = options.bands.length;
       for (var i = 0; i < len; i++) {
-        args = args.concat(["-b", String(options.bands[i])]);
+        args = args.concat(["-b", "" + options.bands[i]]);
       }
     }
 
-    if(options.nodata) {
+    if (options.nodata) {
       args = args.concat(["-a_nodata", options.nodata]);
     }
 

--- a/lib/activities/translate.js
+++ b/lib/activities/translate.js
@@ -1,0 +1,52 @@
+"use strict";
+
+var assert = require("assert");
+
+var clone = require("clone"),
+    gdal = require("gdal");
+
+var output = require("./output"),
+    shell = require("./shell");
+
+module.exports = function translate(localInputPath, outputUri, options, callback) {
+  return output(outputUri, callback, function(err, localOutputPath, done) {
+    if (err) {
+      return callback(err);
+    }
+
+    var args = [];
+    if(options.outputFormat) {
+      args = args.concat(["-of", options.outputFormat]);
+    }
+
+    if(options.bands) {
+      var len = options.bands.length;
+      for (var i = 0; i < len; i++) {
+        args = args.concat(["-b", String(options.bands[i])]);
+      }
+    }
+
+    if(options.nodata) {
+      args = args.concat(["-a_nodata", options.nodata]);
+    }
+
+    args = args.concat([
+      localInputPath,
+      localOutputPath
+    ]);
+
+    var env = clone(process.env);
+
+    env.GDAL_CACHEMAX = 256;
+    env.GDAL_DISABLE_READDIR_ON_OPEN = true;
+    env.CHECK_WITH_INVERT_PROJ = true; // handle -180/180, 90/-90 correctly
+    env.CPL_VSIL_CURL_ALLOWED_EXTENSIONS = ".tiff,.zip,.vrt";
+
+    return shell("gdal_translate", args, {
+      env: env,
+      timeout: 10 * 60e3 // 10 minutes
+    }, done);
+  });
+};
+
+module.exports.version = "1.0";

--- a/lib/decider.js
+++ b/lib/decider.js
@@ -15,7 +15,7 @@ AWS.config.update({
 
 var swf = new AWS.SWF();
 
-var Decider = function(fn) {
+var DeciderWorker = function(fn) {
   stream.Writable.call(this, {
     objectMode: true,
     highWaterMark: 1 // limit the number of buffered tasks
@@ -75,6 +75,6 @@ var Decider = function(fn) {
   };
 };
 
-util.inherits(Decider, stream.Writable);
+util.inherits(DeciderWorker, stream.Writable);
 
-module.exports = Decider;
+module.exports = DeciderWorker;

--- a/lib/sync_decider.js
+++ b/lib/sync_decider.js
@@ -7,7 +7,7 @@ var P = require("bluebird");
 
 var SyncDeciderContext = require("./sync_decider_context");
 
-var SyncDecider = function(fn) {
+var SyncDeciderWorker = function(fn) {
   stream.Writable.call(this, {
     objectMode: true,
     highWaterMark: 1 // limit the number of buffered tasks
@@ -35,6 +35,6 @@ var SyncDecider = function(fn) {
   };
 };
 
-util.inherits(SyncDecider, stream.Writable);
+util.inherits(SyncDeciderWorker, stream.Writable);
 
-module.exports = SyncDecider;
+module.exports = SyncDeciderWorker;

--- a/lib/sync_decider_context.js
+++ b/lib/sync_decider_context.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var debug = require("debug")("swfr:decider_context"),
-    P = require("bluebird"),
+    Promise = require("bluebird"),
     humanize = require("humanize-plus");
 
 var lookup = require("./activities");
@@ -22,7 +22,7 @@ SyncDeciderContext.prototype.activity = function() {
     var args = Array.prototype.slice.call(arguments, 2),
         context = this;
 
-    return new P(function(resolve, reject) {
+    return new Promise(function(resolve, reject) {
       var activity = lookup(name, version);
 
       if (!activity) {
@@ -67,7 +67,7 @@ SyncDeciderContext.prototype.complete = function(result) {
 };
 
 SyncDeciderContext.prototype.log = function() {
-  console.log.apply(null, arguments);
+  console.log.apply(this, arguments);
 };
 
 Object.defineProperty(SyncDeciderContext.prototype, "status", {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "highland": "^2.4.0",
     "holdtime": "^0.1.1",
     "humanize-plus": "^1.5.0",
+    "mkdirp": "^0.5.1",
     "range": "0.0.3",
     "s3-upload-stream": "^1.0.7",
     "sphericalmercator": "^1.0.3",


### PR DESCRIPTION
This PR adds the ability to write to the local file system as well as S3. The code checks for the prefix to determine whether or not to use the existing `s3_output` code.

Also:
- Export the `Decider` so that other projects can use it.
- Allow some actions to pass the `-overwrite` flag into GDAL.
- Added a `gdal_translate` action (which I used to coerce certain imagery into RGB
- Solved the issue of argument list overflow for `gdalbuildvrt` activity on large file lists. 
