### PR TITLE
Multiple output files for activities; allow activities to be a package

### DIFF
--- a/examples/activities/reproject.js
+++ b/examples/activities/reproject.js
@@ -7,7 +7,7 @@ var clone = require("clone");
 var output = require("../../lib/output"),
     shell = require("../../lib/shell");
 
-module.exports = function reproject(localInputPath, outputUri, options, callback) {
+module.exports = function reproject(inputPath, outputUri, options, callback) {
   try {
     assert.ok(options.targetSRS, "reproject: Target SRS is required");
   } catch (err) {
@@ -40,7 +40,7 @@ module.exports = function reproject(localInputPath, outputUri, options, callback
     }
 
     args = args.concat([
-      localInputPath,
+      inputPath,
       localOutputPath
     ]);
 

--- a/examples/activities/resample.js
+++ b/examples/activities/resample.js
@@ -7,7 +7,7 @@ var clone = require("clone");
 var output = require("../../lib/output"),
     shell = require("../../lib/shell");
 
-module.exports = function resample(localInputPath, outputUri, options, callback) {
+module.exports = function resample(inputPath, outputUri, options, callback) {
   try {
     assert.ok(Array.isArray(options.targetExtent), "resample: targetExtent must be an array");
     assert.equal(4, options.targetExtent.length, "resample: targetExtent must be an array of 4 elements");
@@ -69,7 +69,7 @@ module.exports = function resample(localInputPath, outputUri, options, callback)
     }
 
     args = args.concat([
-      localInputPath,
+      inputPath,
       localOutputPath
     ]);
 

--- a/examples/activities/translate.js
+++ b/examples/activities/translate.js
@@ -8,7 +8,7 @@ var clone = require("clone"),
 var output = require("../../lib/output"),
     shell = require("../../lib/shell");
 
-module.exports = function translate(localInputPath, outputUri, options, callback) {
+module.exports = function translate(inputPath, outputUri, options, callback) {
   return output(outputUri, callback, function(err, localOutputPath, done) {
     if (err) {
       return callback(err);
@@ -31,7 +31,7 @@ module.exports = function translate(localInputPath, outputUri, options, callback
     }
 
     args = args.concat([
-      localInputPath,
+      inputPath,
       localOutputPath
     ]);
 

--- a/index.js
+++ b/index.js
@@ -9,5 +9,6 @@ var activities = require("./lib/activities"),
 module.exports.activities = activities;
 module.exports.activity = activity;
 module.exports.decider = decider;
-module.exports.output = output;
+module.exports.singleOutput = output.singleOutput;
+module.exports.multiOutput = output.multiOutput;
 module.exports.shell = shell;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 "use strict";
 
-var activity = require("./lib/activity"),
+var activities = require("./lib/activities"),
+    activity = require("./lib/activity"),
     decider = require("./lib/decider"),
     output = require("./lib/output"),
     shell = require("./lib/shell");
 
+module.exports.activities = activities;
 module.exports.activity = activity;
 module.exports.decider = decider;
 module.exports.output = output;

--- a/lib/activity-handler.js
+++ b/lib/activity-handler.js
@@ -9,10 +9,10 @@ var async = require("async"),
 
 var activities = require("./activities");
 
-var activityHandler = function activityHandler(activitiesFolder, id) {
+var activityHandler = function activityHandler(activities, id) {
   id = id || 1;
 
-  var lookup = activities(activitiesFolder);
+  var lookup = activities;
 
   return function(task, callback) {
     console.log("worker #%d:", id, task);

--- a/lib/activity-worker.js
+++ b/lib/activity-worker.js
@@ -8,7 +8,8 @@ var assert = require("assert"),
     util = require("util");
 
 var _ = require("highland"),
-    AWS = require("aws-sdk");
+    AWS = require("aws-sdk"),
+    clone = require("clone");
 
 var payloadPersister = require("./payload-persister");
 

--- a/lib/activity.js
+++ b/lib/activity.js
@@ -10,7 +10,8 @@ var _ = require("highland"),
     AWS = require("aws-sdk"),
     debug = require("debug");
 
-var activityHandler = require("./activity-handler"),
+var activities = require("./activities"),
+    activityHandler = require("./activity-handler"),
     ActivityWorker = require("./activity-worker");
 
 var log = debug("swfr:activity");
@@ -34,7 +35,9 @@ var swf = new AWS.SWF();
  * Available options:
  * * domain - Workflow domain (required)
  * * taskList - Task list
- * * activitiesFolder - If no fn is specified, use an activityHandler
+ * * activities or
+ * * activitiesFolder - If no fn is specified, pass in activities explicitly or 
+ * *                    pass in an activitiesFolder to use an activityHandler
  * *                    who's activities are in this folder.
  * * workerId - Worker ID, for debugging.
  */
@@ -42,8 +45,12 @@ module.exports = function(options, fn) {
   assert.ok(options.domain, "options.domain is required");
 
   if (!fn) {
-    assert.ok(options.activitiesFolder, "options.activitiesFolder required if no handler specified");
-    fn = activityHandler(options.activitiesFolder, options.workerId);
+    if(!options.activities) {
+      assert.ok(options.activitiesFolder, "options.activitiesFolder required if no handler specified");
+      options.activities = activities(options.activitiesFolder);
+    }
+
+    fn = activityHandler(options.activities, options.workerId);
   }
 
   options.taskList = options.taskList || "defaultTaskList";

--- a/lib/activity.js
+++ b/lib/activity.js
@@ -7,10 +7,13 @@ var assert = require("assert"),
     util = require("util");
 
 var _ = require("highland"),
-    AWS = require("aws-sdk");
+    AWS = require("aws-sdk"),
+    debug = require("debug");
 
 var activityHandler = require("./activity-handler"),
     ActivityWorker = require("./activity-worker");
+
+var log = debug("swfr:activity");
 
 var agent = new https.Agent({
   // Infinity just boosts the max value; in practice this will be no larger
@@ -50,7 +53,7 @@ module.exports = function(options, fn) {
   var source = _(function(push, next) {
     // TODO note: activity types need to be registered in order for workflow
     // executions to not fail
-
+    log("POLLING FOR ACTIVITES.. %s %s %s", AWS.config.region, options.domain, options.taskList);
     var poll = swf.pollForActivityTask({
       domain: options.domain,
       taskList: {
@@ -58,6 +61,7 @@ module.exports = function(options, fn) {
       },
       identity: util.format("swfr@%s:%d", os.hostname(), process.pid)
     }, function(err, data) {
+      log(JSON.stringify(data, null, 2));
       if (err) {
         console.warn(err.stack);
 

--- a/lib/decider.js
+++ b/lib/decider.js
@@ -7,10 +7,14 @@ var assert = require("assert"),
     util = require("util");
 
 var _ = require("highland"),
-    AWS = require("aws-sdk");
+    AWS = require("aws-sdk"),
+    debug = require("debug");
 
-var DeciderWorker = require("./decider-worker"),
+var activities = require("./activities"),
+    DeciderWorker = require("./decider-worker"),
     SyncDeciderWorker = require("./sync-decider-worker");
+
+var log = debug("swfr:decider");
 
 AWS.config.update({
   region: process.env.AWS_DEFAULT_REGION || AWS.config.region || "us-east-1"
@@ -26,7 +30,10 @@ var swf = new AWS.SWF();
 // TODO Distributor
 module.exports = function(options, fn) {
   if (options.sync) {
-    assert.ok(options.activitiesFolder, "options.activitiesFolder is required");
+    if(!options.activities) {
+      assert.ok(options.activitiesFolder, "options.activities or options.activitiesFolder is required");
+      options.activities = activities(options.activitiesFolder);
+    }
 
     var worker = new EventEmitter();
 
@@ -34,7 +41,7 @@ module.exports = function(options, fn) {
       objectMode: true
     });
 
-    source.pipe(new SyncDeciderWorker(fn, options.activitiesFolder));
+    source.pipe(new SyncDeciderWorker(fn, options.activities));
 
     worker.cancel = function() {
       source.end();
@@ -87,7 +94,7 @@ module.exports = function(options, fn) {
     // TODO get events from an LRU cache (which means requesting events in
     // reverse order)
     // in batches of 100 (or whatever the page size is set to)
-    console.log("POLLING.. %s %s", process.env.AWS_DEFAULT_REGION, options.domain);
+    log("POLLING FOR DECISIONS.. %s %s %s", AWS.config.region, options.domain, options.taskList);
     var poll = swf.pollForDecisionTask({
       domain: options.domain,
       taskList: {
@@ -95,7 +102,7 @@ module.exports = function(options, fn) {
       },
       identity: util.format("swfr@%s:%d", os.hostname(), process.pid)
     }, function(err, data) {
-      console.log(data);
+      log(JSON.stringify(data, null, 2));
       if (err) {
         console.warn(err.stack);
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,19 +1,119 @@
 "use strict";
 
-var fs = require("fs"),
+var assert = require("assert"),
+    os = require("os"),
     path = require("path"),
-    url = require("url");
+    url = require("url"),
+    util = require("util");
 
-var debug = require("debug"),
-    mkdirp = require("mkdirp");
+var AWS = require("aws-sdk"),
+    debug = require("debug"),
+    fse = require("fs-extra"),
+    holdtime = require("holdtime"),
+    mkdirp = require("mkdirp"),
+    Promise = require("bluebird"),
+    s3UploadStream = require("s3-upload-stream"),
+    tmp = require("tmp"),
+    _ = require("underscore");
 
-var s3Output = require("./s3_output");
+var log = debug("swfr:upload");
 
-module.exports = function(outputUri, done, fn) {
+var ensureDir = Promise.promisify(fse.ensureDir);
+var copy = Promise.promisify(fse.copy);
+
+tmp.setGracefulCleanup();
+
+var getContentType = function(extension) {
+  switch (extension.toLowerCase()) {
+  case ".tif":
+  case ".tiff":
+    return "image/tiff";
+
+  case ".vrt":
+    return "application/xml";
+
+  default:
+    return "application/octet-stream";
+  }
+};
+
+var s3Upload = Promise.promisify(function(sourcePath, outputUri, done) {
+  AWS.config.update({
+    region: process.env.AWS_DEFAULT_REGION || AWS.config.region || "us-east-1"
+  });
+
+  var s3Stream = s3UploadStream(new AWS.S3());
+
+  var outputURI = url.parse(outputUri),
+      extension = path.extname(outputUri);
+
+  var uploadData = {
+    Bucket: outputURI.hostname,
+    Key: outputURI.pathname.slice(1),
+    ACL: "public-read", // TODO hard-coded
+    ContentType: getContentType(extension)
+  };
+
+  log(util.format("S3 UPLOADING:\n%s", JSON.stringify(uploadData, null, 2)));
+
+  var upload = s3Stream.upload(uploadData);
+
+  var cleanup = holdtime(function() {
+    log("upload: %dms", arguments[arguments.length - 1]);
+  });
+
+  upload.on("error", cleanup);
+  upload.on("uploaded", cleanup);
+
+  upload.on("error", function(err) {
+    return done(new Error(err));
+  });
+
+  // cleanup can't be used, as it would propagate the info as an error
+  upload.on("uploaded", function(info) {
+    return done(null, outputUri);
+  });
+
+  return fse.createReadStream(sourcePath).pipe(upload);
+});
+
+var singleS3Output = function(outputUri, done, fn) {
+  var extension = path.extname(outputUri);
+
+  return tmp.tmpName({
+    postfix: extension
+  }, function(err, localOutputPath) {
+    if (err) {
+      return done(err);
+    }
+
+    return fn(null, localOutputPath, function(err, save) {
+      if (err) {
+        // wrapped function failed; propagate the error
+        return done(err);
+      }
+
+      if (save == null) {
+        return done(new Error("Activity must create output in order to upload to s3!"));
+      }
+
+      return s3Upload(localOutputPath, outputUri)
+        .then(function(path) {
+          return done(null, outputUri);
+        })
+        .catch(function(err) {
+          return done(err);
+        });
+    });
+  });
+};
+
+
+module.exports.singleOutput = function(outputUri, done, fn) {
   var uri = url.parse(outputUri);
 
   if (uri.protocol === "s3:") {
-    return s3Output(outputUri, done, fn);
+    return singleS3Output(outputUri, done, fn);
   }
 
   // Local output
@@ -31,6 +131,50 @@ module.exports = function(outputUri, done, fn) {
       }
 
       return done(null, outputUri);
+    });
+  });
+};
+
+module.exports.multiOutput = function(outputs, done, fn) {
+  assert.ok(Array.isArray(outputs), "resample: targetExtent must be an array");
+
+  return tmp.dir({ unsafeCleanup: true}, function(err, workingDir) {
+    if (err) {
+      return done(err);
+    }
+
+    return fn(null, workingDir, function(err, localOutputs) {
+      if (err) {
+        return done.apply(null, arguments);
+      }
+
+      assert.ok(outputs.length === localOutputs.length,
+                util.format("Length of outputs URIs (%d) must be equal to length of local outputs (%d)", outputs.length, localOutputs.length));
+
+      return Promise
+        .resolve(_.zip(localOutputs, outputs))
+        .map(function(sourceTarget) {
+          var source = sourceTarget[0];
+          var target = sourceTarget[1];
+
+          var uri = url.parse(target);
+
+          if (uri.protocol === "s3:") {
+            return s3Upload(source, target);
+          } else {
+            var d = path.dirname(target);
+            return ensureDir(d)
+              .then(function(d) {
+                return copy(source, target);
+              });
+          }
+        }, { concurrency: os.cpus().length })
+        .then(function(outputs) {
+          return done(null, outputs);
+        })
+        .catch(function(err) {
+          return done(err);
+        });
     });
   });
 };

--- a/lib/s3_output.js
+++ b/lib/s3_output.js
@@ -2,7 +2,8 @@
 
 var fs = require("fs"),
     path = require("path"),
-    url = require("url");
+    url = require("url"),
+    util = require("util");
 
 var AWS = require("aws-sdk"),
     debug = require("debug"),
@@ -43,23 +44,26 @@ module.exports = function(output, done, callback) {
   return tmp.tmpName({
     postfix: extension
   }, function(err, outputFilename) {
-    return callback(err, outputFilename, function(err, save) {
+    return callback(err, outputFilename, function(err, outputs) {
       if (err) {
         // wrapped function failed; propagate the error
         return done(err);
       }
 
       if (save == null) {
-        log("ignoring output for %s", output);
-        return done();
+        return done(new Error("Activity must create output in order to upload to s3!"));
       }
 
-      var upload = s3Stream.upload({
+      var uploadData = {
         Bucket: outputURI.hostname,
         Key: outputURI.pathname.slice(1),
         ACL: "public-read", // TODO hard-coded
         ContentType: getContentType(extension)
-      });
+      };
+
+      log(util.format("S3 UPLOADING:\n%s", JSON.stringify(uploadData, null, 2)));
+
+      var upload = s3Stream.upload(uploadData);
 
       var cleanup = holdtime(function() {
         log("upload: %dms", arguments[arguments.length - 1]);

--- a/lib/sync-decider-context.js
+++ b/lib/sync-decider-context.js
@@ -7,13 +7,11 @@ var debug = require("debug")("swfr:decider_context"),
     Promise = require("bluebird"),
     humanize = require("humanize-plus");
 
-var activities = require("./activities");
-
-var SyncDeciderContext = function(task, activitiesFolder) {
+var SyncDeciderContext = function(task, activities) {
   this.task = task;
   this.result = null;
   this.userData = {};
-  this.lookup = activities(activitiesFolder);
+  this.lookup = activities;
 };
 
 SyncDeciderContext.prototype.activity = function() {

--- a/lib/sync-decider-worker.js
+++ b/lib/sync-decider-worker.js
@@ -3,11 +3,11 @@
 var stream = require("stream"),
     util = require("util");
 
-var P = require("bluebird");
+var Promise = require("bluebird");
 
 var SyncDeciderContext = require("./sync-decider-context");
 
-var SyncDeciderWorker = function(fn, activitiesFolder) {
+var SyncDeciderWorker = function(fn, activities) {
   stream.Writable.call(this, {
     objectMode: true,
     highWaterMark: 1 // limit the number of buffered tasks
@@ -15,11 +15,11 @@ var SyncDeciderWorker = function(fn, activitiesFolder) {
 
   this._write = function(task, encoding, callback) {
     // pass the input to the function and provide the rest as the context
-    var context = new SyncDeciderContext(task, activitiesFolder),
-        chain = P.bind(context),
+    var context = new SyncDeciderContext(task, activities),
+        chain = Promise.bind(context),
         input = task.input;
 
-    P
+    Promise
       .bind(context)
       .then(fn.bind(context, chain, input)) // partially apply the worker fn w/ the input
       .catch(function(err) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bluebird": "^2.9.13",
     "clone": "^1.0.2",
     "debug": "^2.1.3",
+    "fs-extra": "^0.23.1",
     "gdal": "^0.5.0",
     "highland": "^2.4.0",
     "holdtime": "^0.1.1",
@@ -24,6 +25,7 @@
     "require-env": "0.0.4",
     "s3-upload-stream": "^1.0.7",
     "sphericalmercator": "^1.0.3",
-    "tmp": "0.0.26"
+    "tmp": "0.0.26",
+    "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
This changes the `output` package export and splits it into two: `singleOutput` and `multiOutput`.
This also changes things so you can pass in activities explicitly, which is good if you want to hold you activities in an external package and bring them in to a decider so that it can be run in a sync context.
